### PR TITLE
macOS compatibility

### DIFF
--- a/rM-sync.sh
+++ b/rM-sync.sh
@@ -20,7 +20,13 @@ LOG="sync.log"                          # Log file name in $MAINDIR
 BACKUPLIST="files.json"
 
 # Behaviour
-NOTIFICATION="/usr/bin/notify-send"     # Notification script
+notification() {
+  if [ "$(uname)" == "Linux" ]; then
+    /usr/bin/notify-send $1 $2           # Notification script
+  elif [ "$(uname)" == "Darwin" ]; then
+    osascript -e "display notification \"$2\" with title \"$1\""
+  fi
+}
 
 LOG="$MAINDIR/$(date +%y%m%d)-$LOG"
 
@@ -117,10 +123,10 @@ else
   ERROR=1
 fi
 $DATE >> $LOG
-if [ -n "$NOTIFICATION" ]; then
-  if [ $ERROR ];then
-    $NOTIFICATION "ERROR in rM Sync!" "$ERRORREASON"
+if typeset -f notification > /dev/null; then
+  if [ $ERROR ]; then
+    notification "ERROR in rM Sync!" "$ERRORREASON"
   else
-    $NOTIFICATION "rM Sync Successfull"
+    notification "rM Sync Successfull"
   fi
 fi

--- a/rM-sync.sh
+++ b/rM-sync.sh
@@ -109,7 +109,7 @@ if [ $? == "0" ]; then
         do
             [ -e "$file" ] || continue
             echo -n $(basename "$file") ": "
-            curl --form "file=@\"$file\"" http://10.11.99.1/upload
+            curl --form "file=@\"$file\"" http://$RMIP/upload
             echo "."
             if [ 0 -eq $? ]; then rm "$file"; fi;
         done

--- a/rM-sync.sh
+++ b/rM-sync.sh
@@ -61,9 +61,12 @@ if [ $? == "0" ]; then
             ERRORREASON=$ERRORREASON$'\n scp command failed'
             ERROR=1
           fi
-          echo "[" > "$BACKUPDIR$TODAY$BACKUPLIST"
-          find "$BACKUPDIR$TODAY" -name *.metadata -type f -exec sed -s '$a,' {} + | sed '$d' >> "$BACKUPDIR$TODAY$BACKUPLIST"
-          echo "]" >> "$BACKUPDIR$TODAY$BACKUPLIST"
+          # sed -s does not work on macOS (https://unix.stackexchange.com/a/131940)
+          if [ "$(uname)" == "Linux" ]; then
+            echo "[" > "$BACKUPDIR$TODAY$BACKUPLIST"
+            find "$BACKUPDIR$TODAY" -name *.metadata -type f -exec sed -s '$a,' {} + | sed '$d' >> "$BACKUPDIR$TODAY$BACKUPLIST"
+            echo "]" >> "$BACKUPDIR$TODAY$BACKUPLIST"
+          fi
           echo "BACKUP END" | tee -a $LOG
           ;;
 

--- a/rM-sync.sh
+++ b/rM-sync.sh
@@ -30,6 +30,9 @@ notification() {
 
 LOG="$MAINDIR/$(date +%y%m%d)-$LOG"
 
+# Create MAINDIR if it does not exist
+mkdir -p $MAINDIR
+
 echo $'\n' >> $LOG
 date >> $LOG
 

--- a/rM-sync.sh
+++ b/rM-sync.sh
@@ -16,7 +16,7 @@ MAINDIR="$HOME/rM"
 BACKUPDIR="$MAINDIR/backup/"             # rotating backups of all rM contents
 UPLOADDIR="$MAINDIR/upload/"             # all files here will be sent to rM
 OUTPUTDIR="$MAINDIR/files/"              # PDFs of everything on the rM
-LOG="sync.log"                          # Log file name in $MAINDIR
+LOG="sync.log"                           # Log file name in $MAINDIR
 BACKUPLIST="files.json"
 
 # Behaviour
@@ -50,8 +50,7 @@ if [ $? == "0" ]; then
   while getopts bdu opt
   do
      case $opt in
-       b) 
-
+       b)
           # Backup files
           echo "BEGIN BACKUP" | tee -a $LOG
           mkdir -p "$BACKUPDIR$TODAY"
@@ -75,7 +74,7 @@ if [ $? == "0" ]; then
           echo "BEGIN DOWNLOAD" | tee -a $LOG
           mkdir -p "$OUTPUTDIR"
           ls -1 "$BACKUPDIR$TODAY" | sed -e 's/\..*//g' | awk '!a[$0]++' > "$OUTPUTDIR/index"
-          
+
           echo "[" > "$OUTPUTDIR/index.json";
           for file in "$BACKUPDIR$TODAY"/*.metadata;
           do


### PR DESCRIPTION
Hey 👋 While searching for a way to backup my reMarkable 2 without using the cloud, I found your helpful script. Thank you very much for sharing your solution. Since I am mainly working on macOS, I made some minor additions so the script can be used both on Linux and macOS.

The biggest change is the replacement of the notification script with a function, which calls the right notification procedure based on the OS. b696614

Unfortunately, I was not able to port the backup list to macOS, since the `--separate` flag of `sed` is not available on macOS. Maybe you could provide me with a sample backup list so I can look into an alternative solution for macOS? 8eb20ab

Some additional minor changes:
* If the MAINDIR does not exist, the script creates it automatically. This allows the script to be run out of the box with the default settings. e5d297d
* The hard coded IP address in the upload section was replaced. 4070ba1
* Clean up of some spaces and line breaks da8e08b

I hope you find these contributions helpful. Please check, if my changes break anything on Linux, since I was not able to test on a Linux machine. If you find any bugs, I would be happy to update my pull request.